### PR TITLE
Proper phone number validation

### DIFF
--- a/dist/assets/mail/jqBootstrapValidation.js
+++ b/dist/assets/mail/jqBootstrapValidation.js
@@ -172,7 +172,7 @@
                         // ---------------------------------------------------------
                         //                                                    NUMBER
                         // ---------------------------------------------------------
-                        if ($this.attr("type") !== undefined && $this.attr("type").toLowerCase() === "number") {
+                        if ($this.attr("type") !== undefined && $this.attr("type").toLowerCase() === "tel") {
                             message = settings.builtInValidators.number.message;
                             if ($this.data("validationNumberMessage")) {
                                 message = $this.data("validationNumberMessage");


### PR DESCRIPTION
On line 175, changed attribute type from "number" to "tel" in order to match the html. Before the change, letters were being accepted as valid input for the phone number field.